### PR TITLE
Added InitAction to StructReArray

### DIFF
--- a/RelaStructures.UT/StructReArrayTests.cs
+++ b/RelaStructures.UT/StructReArrayTests.cs
@@ -16,7 +16,7 @@ namespace RelaStructures.UT
         {
             from.Move(ref to);
         }
-
+        
         public void ClearActionAdv(ref TestStructAdv obj)
         {
             obj.Clear();
@@ -25,6 +25,20 @@ namespace RelaStructures.UT
         public void MoveActionAdv(ref TestStructAdv from, ref TestStructAdv to)
         {
             from.Move(ref to);
+        }
+
+        public void ClearActionArr(ref TestStructArr obj)
+        {
+            obj.Clear();
+        }
+
+        public void MoveActionArr(ref TestStructArr from, ref TestStructArr to)
+        {
+            from.Move(ref to);
+        }
+        public void InitActionArr(ref TestStructArr obj)
+        {
+            obj.Init();
         }
 
         [TestMethod]
@@ -201,6 +215,26 @@ namespace RelaStructures.UT
                 Sample[sampleIndex] = new FloatStruct(f: expected);
             }
             Assert.AreEqual(expected, Sample[10].F);
+        }
+        [TestMethod]
+        public void InitActionTest()
+        {
+            int expected = 256;
+            RelaStructures.StructReArray<TestStructArr> Sample = new RelaStructures.StructReArray<TestStructArr>(10, 20, ClearActionArr, MoveActionArr, InitActionArr);
+            int sampleIndex = Sample.Length / 2;
+            for (int i = 0; i < Sample.Length; i++)
+                Sample.Request();
+            Assert.AreEqual(Sample[sampleIndex].X.Length, expected);
+        }
+        [TestMethod]
+        public void InitActionOverflowTest()
+        {
+            int expected = 256;
+            RelaStructures.StructReArray<TestStructArr> Sample = new RelaStructures.StructReArray<TestStructArr>(10, 20, ClearActionArr, MoveActionArr, InitActionArr);
+            int sampleIndex = (Sample.MaxLength - Sample.Length) / 2 + Sample.Length;
+            for (int i = 0; i < Sample.MaxLength; i++)
+                Sample.Request();
+            Assert.AreEqual(Sample[sampleIndex].X.Length, expected);
         }
     }
 }

--- a/RelaStructures.UT/TestStructArr.cs
+++ b/RelaStructures.UT/TestStructArr.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace RelaStructures.UT
+{
+    public struct TestStructArr
+    {
+        public float[] X;
+        public float[] Y;
+        public int[] Health;
+        public void Init()
+		{
+            X = new float[256];
+            Y = new float[256];
+            Health = new int[256];
+		}
+        public void Clear()
+        {
+            Array.Clear(X, 0, X.Length);
+            Array.Clear(Y, 0, Y.Length);
+            Array.Clear(Health, 0, Health.Length);
+        }
+
+        public void Move(ref TestStructArr b)
+        {
+            Array.Copy(X, b.X, b.X.Length);
+            Array.Copy(Y, b.Y, b.Y.Length);
+            Array.Copy(Health, b.Health, b.Health.Length);
+        }
+    }
+}

--- a/RelaStructures/StructReArray.cs
+++ b/RelaStructures/StructReArray.cs
@@ -8,24 +8,38 @@ namespace RelaStructures
     {
         public delegate void ClearDelegate(ref T obj);
         public delegate void MoveDelegate(ref T from, ref T to);
+        public delegate void InitDelegate(ref T obj);
 
         public T[] Values;
         public int[] IdsToIndices;
         public int[] IndicesToIds;
-        public ClearDelegate ClearAction; // called when we clear out a struct
-                                          // client should revert target index back to default values
-                                          // e.g. Values[index].X = 0
-        public MoveDelegate MoveAction; // called when we move a struct, args are "values, moving index, target index"
-                                        // what is required here is that the client provide the logic for copying one struct into another
-                                        // e.g. Values[targetIndex].X = Values[movingIndex].X
+        /// <summary>
+        /// <para>Called when we clear out a struct</para>
+        /// <para>Client should revert target index back to default values</para>
+        /// <para>e.g. Values[index].X = 0</para>
+        /// </summary>
+        public ClearDelegate ClearAction;
+        /// <summary>
+        /// <para>Called when we move a struct, args are "values, moving index, target index"</para>
+        /// <para>What is required here is that the client provide the logic for copying one struct into another</para>
+        /// <para>e.g. Values[targetIndex].X = Values[movingIndex].X</para>
+        /// </summary>
+        public MoveDelegate MoveAction;
+        /// <summary>
+        /// <para>called when we construct or resize a struct</para>
+        /// <para>alllows the client to preallocate arrays inside the struct</para>
+        /// <para>e.g. Values[targetIndex].X = new int[256]</para>
+        /// </summary>
+        public InitDelegate InitAction;
         public int Count { get; private set; } = 0;
         public int Length { get; private set; } = 0;
         public int MaxLength;
 
-        public StructReArray(int length, int maxlength, ClearDelegate clearAction, MoveDelegate moveAction)
+        public StructReArray(int length, int maxlength, ClearDelegate clearAction, MoveDelegate moveAction, InitDelegate initAction = null)
         {
             ClearAction = clearAction;
             MoveAction = moveAction;
+            InitAction = initAction;
 
             Length = length;
             MaxLength = maxlength;
@@ -38,6 +52,7 @@ namespace RelaStructures
                 Values[i] = new T();
                 IdsToIndices[i] = i;
                 IndicesToIds[i] = i;
+                InitAction?.Invoke(ref Values[i]);
             }
         }
 
@@ -89,6 +104,7 @@ namespace RelaStructures
                 Values[i] = new T();
                 IdsToIndices[i] = i;
                 IndicesToIds[i] = i;
+                InitAction?.Invoke(ref Values[i]);
             }
         }
 

--- a/RelaStructures/StructReArray.cs
+++ b/RelaStructures/StructReArray.cs
@@ -52,7 +52,11 @@ namespace RelaStructures
                 Values[i] = new T();
                 IdsToIndices[i] = i;
                 IndicesToIds[i] = i;
-                InitAction?.Invoke(ref Values[i]);
+            }
+            if (InitAction != null)
+            {
+                for (int i = 0; i < Length; i++)
+                    InitAction.Invoke(ref Values[i]);
             }
         }
 
@@ -104,7 +108,11 @@ namespace RelaStructures
                 Values[i] = new T();
                 IdsToIndices[i] = i;
                 IndicesToIds[i] = i;
-                InitAction?.Invoke(ref Values[i]);
+            }
+            if (InitAction != null)
+            {
+                for (int i = Count; i < Length; i++)
+                    InitAction.Invoke(ref Values[i]);
             }
         }
 


### PR DESCRIPTION
InitAction is an optional delegate called when constructing or resizing.
Use InitAction to preallocate arrays within structs.

Switched some comments to use `<summary>`